### PR TITLE
Added "check" key

### DIFF
--- a/mongokit/document.py
+++ b/mongokit/document.py
@@ -86,7 +86,7 @@ class DocumentProperties(SchemaProperties):
                         raise BadIndexError(
                           "'fields' key must be specify in indexes")
                     for key, value in index.iteritems():
-                        if key not in ['fields', 'unique', 'ttl']:
+                        if key not in ['fields', 'unique', 'ttl', 'check']:
                             raise BadIndexError(
                               "%s is unknown key for indexes" % key)
                         if key == "fields":


### PR DESCRIPTION
Line 89 of document.py would raise an exception if check was a key, thereby preventing the check feature from being used.
