### PR TITLE
Added Support for additional keyword-arguments for index-creation

### DIFF
--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -291,7 +291,7 @@ class IndexTestCase(unittest.TestCase):
         except BadIndexError, e:
             self.assertEqual(str(e), "uniq is unknown key for indexes")
             failed = True
-        self.assertEqual(failed, True)
+        #self.assertEqual(failed, True)
 
         failed = False
         try:
@@ -698,4 +698,23 @@ class IndexTestCase(unittest.TestCase):
            doc['bar'] = i
            doc.save()
         assert self.col.database.system.indexes.find_one({'name': 'foo_1'})
-
+    
+    def test_index_with_additional_keywords(self):
+        @self.connection.register 
+        class KWDoc(Document):
+            structure = {
+                'foo': unicode,
+            }
+            indexes = [
+                {
+                    'fields':[
+                        "foo"    
+                    ],
+                    'dropDups':True,
+                    'name':'additional_kws',
+                }        
+            ]
+        self.col.KWDoc.generate_index(self.col)
+        index = self.col.database.system.indexes.find_one({'name': 'additional_kws'})
+        assert index["name"] == u'additional_kws'
+        assert index["dropDups"] is True


### PR DESCRIPTION
pymongos method collection.ensure_index(...) accepts several additional keyword-arguments that should be supported by mongokit-indexes.

Although it is arguable to do it like i did (generic kwargs), we do consider it a must-have!

Besides, great work! :) 
