### PR TITLE
Replace pymongo.objectid with bson.objectid.

### DIFF
--- a/mongokit/document.py
+++ b/mongokit/document.py
@@ -45,7 +45,7 @@ from bson import BSON
 from bson.binary import Binary
 from bson.code import Code
 from bson.dbref import DBRef
-from pymongo.objectid import ObjectId
+from bson.objectid import ObjectId
 import re
 from copy import deepcopy
 from uuid import UUID, uuid4
@@ -397,7 +397,7 @@ class Document(SchemaDocument):
         save the document into the db.
 
         if uuid is True, a uuid4 will be automatiquely generated
-        else, the pymongo.ObjectId will be used.
+        else, the bson.ObjectId will be used.
 
         If validate is True, the `validate` method will be called before
         saving. Not that the `validate` method will be called *before* the

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -28,7 +28,7 @@
 import unittest
 
 from mongokit import *
-from pymongo.objectid import ObjectId
+from bson.objectid import ObjectId
 
 
 class ApiTestCase(unittest.TestCase):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -29,7 +29,7 @@ import unittest
 
 from mongokit import *
 from mongokit.auth import User
-from pymongo.objectid import ObjectId
+from bson.objectid import ObjectId
 
 import logging
 logging.basicConfig()

--- a/tests/test_autoref.py
+++ b/tests/test_autoref.py
@@ -31,7 +31,7 @@ import logging
 logging.basicConfig(level=logging.DEBUG)
 
 from mongokit import *
-from pymongo.objectid import ObjectId
+from bson.objectid import ObjectId
 
 class AutoRefTestCase(unittest.TestCase):
     """Tests AutoRef case"""

--- a/tests/test_custom_types.py
+++ b/tests/test_custom_types.py
@@ -106,8 +106,8 @@ class CustomTypesTestCase(unittest.TestCase):
 
 
     def test_instance_type(self):
-        from pymongo.objectid import ObjectId
         from bson.dbref import DBRef
+        from bson.objectid import ObjectId
         class Bla(ObjectId):pass
         class Ble(DBRef):pass
         class MyDoc(Document):

--- a/tests/test_ext_mongodb_auth.py
+++ b/tests/test_ext_mongodb_auth.py
@@ -31,7 +31,7 @@ import logging
 logging.basicConfig(level=logging.DEBUG)
 
 from mongokit import *
-from pymongo.objectid import ObjectId
+from bson.objectid import ObjectId
 
 admin_created = False
 

--- a/tests/test_gridfs.py
+++ b/tests/test_gridfs.py
@@ -28,7 +28,7 @@
 import unittest
 
 from mongokit import *
-from pymongo.objectid import ObjectId
+from bson.objectid import ObjectId
 from gridfs import NoFile
 
 

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -28,7 +28,7 @@
 import unittest
 
 from mongokit import *
-from pymongo.objectid import ObjectId
+from bson.objectid import ObjectId
 from mongokit.helpers import i18nDotedDict
 
 

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -28,7 +28,7 @@
 import unittest
 
 from mongokit import *
-from pymongo.objectid import ObjectId
+from bson.objectid import ObjectId
 import datetime
 
 

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -28,7 +28,7 @@
 import unittest
 
 from mongokit import *
-from pymongo.objectid import ObjectId
+from bson.objectid import ObjectId
 from datetime import datetime
 
 


### PR DESCRIPTION
The pymongo.\* aliases for bson modules were removed in PyMongo 2.2.
