### PR TITLE
Fixes formatting error when throwing MaxDocumentSizeError in Document.validate()

### DIFF
--- a/mongokit/document.py
+++ b/mongokit/document.py
@@ -231,7 +231,7 @@ class Document(SchemaDocument):
 
         if size > size_limit:
             raise MaxDocumentSizeError("The document size is too big, documents "
-              "lower than %s is allowed (got %s bytes)" % size_limit_str, size)
+              "lower than %s is allowed (got %s bytes)" % (size_limit_str, size))
         if auto_migrate:
             error = None
             try:


### PR DESCRIPTION
I guess nobody else has hit this before, but the code for generating the error message for the MaxDocumentSizeError in Document.validate() is incorrect. The two formatting parameters should be enclosed inside of parentheses. 

This patch fixes the problem.
