### PR TITLE
Passing missing keyword arguments from connection to collection.find()

### DIFF
--- a/mongokit/collection.py
+++ b/mongokit/collection.py
@@ -76,9 +76,11 @@ class Collection(PymongoCollection):
             kwargs['read_preference'] = self.read_preference
         if not 'tag_sets' in kwargs and hasattr(self, 'tag_sets'):
             kwargs['tag_sets'] = self.tag_sets
-        if not 'secondary_acceptable_latency_ms' in kwargs and hasattr(self, 'tag_sets'):
+        if not 'secondary_acceptable_latency_ms' in kwargs and\
+                hasattr(self, 'secondary_acceptable_latency_ms'):
             kwargs['secondary_acceptable_latency_ms'] = (
-                self.secondary_acceptable_latency_ms)
+                self.secondary_acceptable_latency_ms
+            )
         return Cursor(self, *args, **kwargs)
     find.__doc__ = PymongoCollection.find.__doc__ + """
         added by mongokit::


### PR DESCRIPTION
I've been using MongoKit for a while for a project and had to hack around this issue before.  

_Problem_:
I noticed that the mongokit.Collection.find() is calling mongokit.Cursor(), which extends pymongo.Cursor().  In this flow, mongokit.Collection.find() is bypassing the pymongo.Collection.find() and is directly calling Cursor().   Keyword arguments (like read_preferences, slave_okay, etc) for the Cursor that are set during Connection initiation are not being passed in this flow.   

I found that I had to set these keyword arguments for all my queries, when I really should be able to just set them on Connection initiation and have it just work for all my queries.

_Solution_:
Added checks for kwargs for the arguments that pymongo is looking for in mongokit.Collection.find().  These kwargs are then passed over to the mongokit.Cursor()->pymongo.Cursor(), similar to how pymongo does it.  Also affects mongokit.Document.find(), since this method essentially calls mongokit.Collection.find()

Let me know if you would like clarification.
