### PR TITLE
Fix off-by-one error in schema_document

### DIFF
--- a/mongokit/schema_document.py
+++ b/mongokit/schema_document.py
@@ -560,7 +560,8 @@ class SchemaDocument(dict):
                 self._raise_exception(SchemaTypeError, path,
                   "%s must be an instance of %s not %s" %(
                     path, type(struct).__name__, type(doc).__name__))
-            if len(doc) != len(struct):
+            struct_length = len(struct) if '_id' in struct else len(struct) - 1
+            if len(doc) != struct_length:
                 struct_doc_diff = list(set(struct).difference(set(doc)))
                 if struct_doc_diff:
                     for field in struct_doc_diff:


### PR DESCRIPTION
On line 563 of `schema_document`, the length of the document being validated is checked against the length of the structure.  If `_id` is not specified in the structure (as standards dictate), this test will fail.

This was noticed when attempting to get migrations working - adding a field did not trigger any error, as it just caused the length test to pass.
