### PR TITLE
setup: Increase required PyMongo version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,11 +58,11 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
     packages = find_packages(),
-        
+
     zip_safe = False,
 
     install_requires = [
-        'pymongo>=2.0.1',
+        'pymongo>=2.5',
     ]
 
 )


### PR DESCRIPTION
We are importing Geo-spacial constants in `__init__.py` that only exist in PyMongo versions 2.5+.  The relevant PyMongo docs showing that these were added in 2.5 [are here.](http://api.mongodb.org/python/current/api/pymongo/collection.html?highlight=geo#pymongo.GEO2D)
