### PR TITLE
Support MongoReplicaSetClient

### DIFF
--- a/mongokit/__init__.py
+++ b/mongokit/__init__.py
@@ -36,7 +36,7 @@ from document import Document, ObjectId
 from versioned_document import VersionedDocument
 from database import Database
 from collection import Collection
-from connection import Connection, MongoClient
+from connection import Connection, MongoClient, MongoReplicaSetClient
 from master_slave_connection import MasterSlaveConnection
 from replica_set_connection import ReplicaSetConnection
 from pymongo import (

--- a/mongokit/connection.py
+++ b/mongokit/connection.py
@@ -27,6 +27,7 @@
 
 try:
     from pymongo import MongoClient as PymongoConnection
+    from pymongo import MongoReplicaSetClient as PymongoReplicaSetConnection
 except ImportError:
     from pymongo import Connection as PymongoConnection
 from database import Database
@@ -102,4 +103,11 @@ class Connection(MongoKitConnection, PymongoConnection):
         MongoKitConnection.__init__(self, *args, **kwargs)
         PymongoConnection.__init__(self, *args, **kwargs)
 
+class __ReplicaConnection(MongoKitConnection, PymongoReplicaSetConnection):
+    def __init__(self, *args, **kwargs):
+        # Specifying that it should run both the inits
+        MongoKitConnection.__init__(self, *args, **kwargs)
+        PymongoReplicaSetConnection.__init__(self, *args, **kwargs)
+
 MongoClient = Connection
+MongoReplicaSetClient = __ReplicaConnection


### PR DESCRIPTION
Added support for MongoReplicaSetClient by inheritance of MongoKitConnection. I could only tested basic functionality.

This should work as MongoReplicaSetClient and MongoClient shares same core architecture for operating DB.
