### PR TITLE
Added __getstate__ and __setstate__ to DotedDict and i18nDotedDict.

### DIFF
--- a/mongokit/helpers.py
+++ b/mongokit/helpers.py
@@ -79,6 +79,12 @@ class i18nDotedDict(dict):
         obj = dict(self)
         return deepcopy(obj, memo)
 
+    def __getstate__(self):
+        return self.__dict__
+
+    def __setstate__(self, d):
+        self.__dict__.update(d)
+
 
 class DotedDict(dict):
     """
@@ -113,6 +119,12 @@ class DotedDict(dict):
     def __deepcopy__(self, memo={}):
         obj = dict(self)
         return deepcopy(obj, memo)
+
+    def __getstate__(self):
+        return self.__dict__
+
+    def __setstate__(self, d):
+        self.__dict__.update(d)
 
 
 class EvalException(Exception):


### PR DESCRIPTION
Noticed that I was receiving a Python error:
   ...
   dict = getstate()
   TypeError: 'NoneType' object is not callable
   ...

when trying to cPickle.dumps a MongoKit document.  I noticed that occurred because a field in my doc was treated as a mongokit.helpers.DotedDict rather than a normal dict.  It appears that without explicitly stating __getstate__ and __setstate__ as a normal dict, the pickling fails.  I have added these functions.  Never know when you need to pickle these objects.
