### PR TITLE
changed the namespace on schema document errors

### DIFF
--- a/mongokit/__init__.py
+++ b/mongokit/__init__.py
@@ -25,7 +25,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-__version__ = "0.9.0"
+__version__ = "0.9.1"
 
 from bson.dbref import DBRef
 from cursor import Cursor

--- a/mongokit/schema_document.py
+++ b/mongokit/schema_document.py
@@ -97,48 +97,51 @@ class CustomType(object):
 # field wich does not need to be declared into the structure
 STRUCTURE_KEYWORDS = []
 
-
-class RequireFieldError(Exception):
+class SchemaDocumentError(Exception):
     pass
 
 
-class StructureError(Exception):
+class RequireFieldError(SchemaDocumentError):
     pass
 
 
-class BadKeyError(Exception):
+class StructureError(SchemaDocumentError):
     pass
 
 
-class AuthorizedTypeError(Exception):
+class BadKeyError(SchemaDocumentError):
     pass
 
 
-class ValidationError(Exception):
+class AuthorizedTypeError(SchemaDocumentError):
     pass
 
 
-class DuplicateRequiredError(Exception):
+class ValidationError(SchemaDocumentError):
     pass
 
 
-class DuplicateDefaultValueError(Exception):
+class DuplicateRequiredError(SchemaDocumentError):
     pass
 
 
-class ModifierOperatorError(Exception):
+class DuplicateDefaultValueError(SchemaDocumentError):
     pass
 
 
-class SchemaTypeError(Exception):
+class ModifierOperatorError(SchemaDocumentError):
     pass
 
 
-class DefaultFieldTypeError(Exception):
+class SchemaTypeError(SchemaDocumentError):
     pass
 
 
-class i18nError(Exception):
+class DefaultFieldTypeError(SchemaDocumentError):
+    pass
+
+
+class i18nError(SchemaDocumentError):
     pass
 
 

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ import codecs
 
 setup(
     name = 'mongokit',
-    version = '0.9.0',  # TODO don't forget to change version in __init__
+    version = '0.9.1',  # TODO don't forget to change version in __init__
 
     description = 'Python mongodb kit',
     long_description = codecs.open('README.md', "r", "utf-8").read(),


### PR DESCRIPTION
Changed the base Exception for the schema document errors.  This way if someone wants to catch all errors related to a schema document they can do it in one pass.  The use case for this is lets say I get an http POST/PUT request and want to return a 400 for any mongokit schema document error but a 500 for a mongodb related error like a connection error.
