### PR TITLE
fix test where to_json method is compare to a string

### DIFF
--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -59,7 +59,9 @@ class JsonTestCase(unittest.TestCase):
         mydoc['bla']['egg'] = datetime.datetime(2010, 1, 1)
         mydoc['spam'] = range(10)
         mydoc.save()
-        assert  mydoc.to_json() == '{"_id": "mydoc", "bla": {"egg": 1262304000000, "foo": "bar", "bar": 42}, "spam": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]}', mydoc.to_json()
+        import json
+        
+        assert  json.loads(mydoc.to_json()) == json.loads('{"_id": "mydoc", "bla": {"egg": 1262304000000, "foo": "bar", "bar": 42}, "spam": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]}'), mydoc.to_json()
         assert  mydoc.to_json_type() == {'_id': 'mydoc', 'bla': {'egg': 1262304000000, 'foo': u'bar', 'bar': 42}, 'spam': [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]}, mydoc.to_json_type()
 
         mydoc = self.col.MyDoc()
@@ -68,7 +70,7 @@ class JsonTestCase(unittest.TestCase):
         mydoc["bla"]["bar"] = 42
         mydoc['spam'] = [datetime.datetime(2000, 1, 1), datetime.datetime(2008, 8, 8)]
         mydoc.save()
-        assert mydoc.to_json() == '{"_id": "mydoc2", "bla": {"egg": null, "foo": "bar", "bar": 42}, "spam": [946684800000, 1218153600000]}', mydoc.to_json()
+        assert json.loads(mydoc.to_json()) == json.loads('{"_id": "mydoc2", "bla": {"egg": null, "foo": "bar", "bar": 42}, "spam": [946684800000, 1218153600000]}'), mydoc.to_json()
         assert mydoc.to_json_type() == {'_id': 'mydoc2', 'bla': {'egg': None, 'foo': u'bar', 'bar': 42}, 'spam': [946684800000, 1218153600000]}, mydoc.to_json_type()
 
     def test_simple_to_json_with_oid(self):
@@ -88,7 +90,7 @@ class JsonTestCase(unittest.TestCase):
         mydoc.save()
         assert  isinstance(mydoc.to_json_type()['_id']['$oid'], basestring), type(mydoc.to_json_type()['_id'])
         assert isinstance(mydoc.to_json(), unicode)
-
+ 
     def test_simple_to_json_with_oid_in_list(self):
         class A(Document):
             structure = {
@@ -101,7 +103,7 @@ class JsonTestCase(unittest.TestCase):
                     'nested':ObjectId,
                 }
             }
-
+ 
         self.connection.register([A, B])
         a = self.col.A()
         a["foo"] = u"bar"
@@ -118,7 +120,7 @@ class JsonTestCase(unittest.TestCase):
         assert  isinstance(b.to_json_type()['bar'][0]['$oid'], basestring), b.to_json_type()
         assert  isinstance(b.to_json_type()['egg']['nested']['$oid'], basestring), b.to_json_type()
         assert "ObjectId" not in b.to_json()
-
+ 
     def test_simple_to_json_with_no_id(self):
         class MyDoc(Document):
             structure = {
@@ -135,7 +137,7 @@ class JsonTestCase(unittest.TestCase):
         mydoc['spam'] = range(10)
         assert  "_id" not in mydoc.to_json_type()
         assert mydoc.to_json() == '{"bla": {"foo": "bar", "bar": 42}, "spam": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]}'
-
+ 
     def test_to_json_custom_type(self):
         class CustomDegree(CustomType):
             mongo_type = int
@@ -146,7 +148,7 @@ class JsonTestCase(unittest.TestCase):
             def to_python(self, value):
                 if value is not None:
                     return str(value)+"C"
-
+ 
         class MyDoc(Document):
             structure = {
                 "doc":{
@@ -167,7 +169,7 @@ class JsonTestCase(unittest.TestCase):
             '{"doc": {"foo": "3C"}, "_id": "mydoc"}',
         )
         self.assertEqual(mydoc.to_json_type(), {"doc": {"foo": "3C"}, "_id": "mydoc"})
-
+ 
     def test_to_json_embeded_doc(self):
         class EmbedDoc(Document):
             structure = {
@@ -197,7 +199,7 @@ class JsonTestCase(unittest.TestCase):
         mydoc.save()
         assert mydoc.to_json() == '{"doc": {"embed": {"_collection": "mongokit", "_database": "test", "_id": "embed", "bla": {"foo": "bar", "bar": 42}, "spam": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]}}, "_id": "mydoc"}'
         assert mydoc.to_json_type() == {"doc": {"embed": {"_id": "embed", "bla": {"foo": "bar", "bar": 42}, "spam": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]}}, "_id": "mydoc"}
-
+ 
     def test_to_json_embeded_doc_with_oid(self):
         class EmbedDoc(Document):
             structure = {
@@ -226,7 +228,7 @@ class JsonTestCase(unittest.TestCase):
         assert isinstance(mydoc.to_json_type()['doc']['embed']['_id']['$oid'], basestring)
         assert mydoc.to_json() == '{"doc": {"embed": {"_collection": "mongokit", "_database": "test", "_id": {"$oid": "%s"}, "bla": {"foo": "bar", "bar": 42}, "spam": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]}}, "_id": {"$oid": "%s"}}' % (
           embed['_id'], mydoc['_id']), mydoc.to_json()
-
+ 
     def test_to_json_with_None_embeded_doc(self):
         class EmbedDoc(Document):
             structure = {
@@ -249,7 +251,7 @@ class JsonTestCase(unittest.TestCase):
         mydoc.save()
         assert mydoc.to_json() == '{"doc": {"embed": null}, "_id": "mydoc"}'
         assert mydoc.to_json_type() == {'doc': {'embed': None}, '_id': 'mydoc'}, mydoc.to_json_type()
-
+ 
     def test_to_json_with_dict_in_list(self):
         class MyDoc(Document):
             structure = {
@@ -262,8 +264,8 @@ class JsonTestCase(unittest.TestCase):
         mydoc.save()
         assert  mydoc.to_json() == '{"foo": [{"bar": "bla", "egg": 3}, {"bar": "bli", "egg": 4}], "_id": "mydoc"}', mydoc.to_json()
         assert  mydoc.to_json_type() == {'foo': [{'bar': u'bla', 'egg': 3}, {'bar': u'bli', 'egg': 4}], '_id': 'mydoc'}
-
-
+ 
+ 
     def test_simple_from_json(self):
         class MyDoc(Document):
             structure = {
@@ -278,7 +280,7 @@ class JsonTestCase(unittest.TestCase):
         mydoc = self.col.MyDoc.from_json(json)
         assert mydoc == {'_id': 'mydoc', 'bla': {'foo': 'bar', 'bar': 42}, 'spam': [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]}
         assert mydoc.collection == self.col
-
+ 
     def test_simple_from_json2(self):
         class MyDoc(Document):
             structure = {
@@ -294,7 +296,7 @@ class JsonTestCase(unittest.TestCase):
         mydoc = self.col.MyDoc.from_json(json)
         assert mydoc == {'_id': 'mydoc2', 'bla': {'foo': 'bar', 'bar': 42, "egg":datetime.datetime(2000, 1, 1, 0, 0)}, 'spam': [datetime.datetime(2000, 1, 1, 0, 0), datetime.datetime(2008, 8, 8, 0, 0)]}, mydoc
         assert mydoc.collection == self.col
-
+ 
     def test_from_json_embeded_doc(self):
         class EmbedDoc(Document):
             structure = {
@@ -312,7 +314,7 @@ class JsonTestCase(unittest.TestCase):
             }
             use_autorefs = True
         self.connection.register([MyDoc, EmbedDoc])
-
+ 
         embed = self.col.EmbedDoc()
         embed['_id'] = u"embed"
         embed["bla"] = {"foo": u"bar", "bar": 42}
@@ -327,7 +329,7 @@ class JsonTestCase(unittest.TestCase):
         mydoc = self.col.MyDoc.from_json(json)
         assert mydoc == {'doc': {'embed': {u'_id': u'embed', u'bla': {u'foo': u'bar', u'bar': 42}, u'spam': [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]}}, '_id': u'mydoc'}, mydoc
         assert isinstance(mydoc['doc']['embed'], EmbedDoc)
-
+ 
     def test_from_json_embeded_doc_with_oid(self):
         class EmbedDoc(Document):
             structure = {
@@ -345,7 +347,7 @@ class JsonTestCase(unittest.TestCase):
             }
             use_autorefs = True
         self.connection.register([MyDoc, EmbedDoc])
-
+ 
         embed = self.col.EmbedDoc()
         embed["bla"] = {"foo": u"bar", "bar": 42}
         embed["spam"] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
@@ -359,8 +361,8 @@ class JsonTestCase(unittest.TestCase):
         doc = self.col.MyDoc.from_json(json)
         assert doc == {'doc': {'embed': {u'_id': embed['_id'], u'bla': {u'foo': u'bar', u'bar': 42}, u'spam': [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]}}, '_id': mydoc['_id']}, doc
         assert isinstance(doc['doc']['embed'], EmbedDoc)
-
-
+ 
+ 
     def test_from_json_with_None_embeded_doc(self):
         class EmbedDoc(Document):
             structure = {
@@ -385,7 +387,7 @@ class JsonTestCase(unittest.TestCase):
         assert json == '{"doc": {"embed": null}, "_id": "mydoc"}'
         doc = self.col.MyDoc.from_json(json)
         assert doc == {'doc': {'embed': None}, '_id': 'mydoc'}
-
+ 
     def test_from_json_embeded_doc_in_list(self):
         class EmbedDoc(Document):
             structure = {
@@ -417,7 +419,7 @@ class JsonTestCase(unittest.TestCase):
         mydoc = self.col.MyDoc.from_json(json)
         assert mydoc == {'doc': {'embed': [{u'_id': u'embed', u'bla': {u'foo': u'bar', u'bar': 42}, u'spam': [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]}]}, '_id': u'mydoc'}, mydoc
         assert isinstance(mydoc['doc']['embed'][0], EmbedDoc)
-
+ 
     def test_from_json_embeded_doc_in_list_with_oid(self):
         class EmbedDoc(Document):
             structure = {
@@ -448,7 +450,7 @@ class JsonTestCase(unittest.TestCase):
         doc = self.col.MyDoc.from_json(json)
         assert doc == {'doc': {'embed': [{u'_id': embed['_id'], u'bla': {u'foo': u'bar', u'bar': 42}, u'spam': [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]}]}, '_id': mydoc['_id']}, doc
         assert isinstance(doc['doc']['embed'][0], EmbedDoc)
-
+ 
     def test_from_json_with_no_embeded_doc_in_list(self):
         class EmbedDoc(Document):
             structure = {
@@ -473,7 +475,7 @@ class JsonTestCase(unittest.TestCase):
         assert json == '{"doc": {"embed": []}, "_id": "mydoc"}'
         mydoc = self.col.MyDoc.from_json(json)
         assert mydoc == {'doc': {'embed': []}, '_id': 'mydoc'}
-
+ 
     def test_from_json_dict_in_list(self):
         class MyDoc(Document):
             structure = {
@@ -486,7 +488,7 @@ class JsonTestCase(unittest.TestCase):
         json = '{"doc": {"embed": [{"foo": "bar", "bar": 42}]}, "_id": "mydoc"}'
         mydoc = self.col.MyDoc.from_json(json)
         assert mydoc == {'doc': {'embed': [{'foo': 'bar', 'bar': 42}]}, '_id': 'mydoc'}, mydoc
-
+ 
     def test_from_json_unicode(self):
         class MyDoc(Document):
             structure = {
@@ -497,7 +499,7 @@ class JsonTestCase(unittest.TestCase):
             }
             use_autorefs = True
         self.connection.register([MyDoc])
-
+ 
         mydoc = self.col.MyDoc()
         mydoc['doc']['name'] = u'bla'
         mydoc['foo'] = u'bar'
@@ -507,7 +509,7 @@ class JsonTestCase(unittest.TestCase):
         assert isinstance(mydoc['foo'], unicode)
         assert isinstance(mydoc2['doc']['name'], unicode)
         assert isinstance(mydoc2['foo'], unicode)
-
+ 
     def test_simple_to_json_from_cursor(self):
         class MyDoc(Document):
             structure = {
@@ -526,7 +528,7 @@ class JsonTestCase(unittest.TestCase):
         mydoc.save()
         json = mydoc.to_json()
         assert json == '{"_id": "mydoc", "bla": {"foo": "bar", "bar": 42}, "spam": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]}'
-
+ 
         mydoc2 = self.col.MyDoc()
         mydoc2['_id'] = u'mydoc2'
         mydoc2["bla"]["foo"] = u"bla"
@@ -534,9 +536,9 @@ class JsonTestCase(unittest.TestCase):
         mydoc2['spam'] = [datetime.datetime(2000, 1, 1), datetime.datetime(2008, 8, 8)]
         mydoc2.save()
         json2 = mydoc2.to_json()
-
+ 
         assert [i.to_json() for i in self.col.MyDoc.fetch()] == [json, json2]
-
+ 
     def test_anyjson_import_error(self):
         import sys
         newpathlist = sys.path
@@ -554,7 +556,7 @@ class JsonTestCase(unittest.TestCase):
         self.assertRaises(ImportError, self.col.MyDoc.from_json, '{"_id":"mydoc", "foo":4}')
         sys.path = newpathlist
         del newpathlist
-
+ 
     def test_to_json_with_dot_notation(self):
         class MyDoc(Document):
             use_dot_notation = True
@@ -567,7 +569,7 @@ class JsonTestCase(unittest.TestCase):
                 "spam":[],
             }
         self.connection.register([MyDoc])
-
+ 
         mydoc = self.col.MyDoc()
         mydoc['_id'] = u'mydoc'
         mydoc["bla"]["foo"] = u"bar"
@@ -575,11 +577,12 @@ class JsonTestCase(unittest.TestCase):
         mydoc['bla']['egg'] = datetime.datetime(2010, 1, 1)
         mydoc['spam'] = range(10)
         mydoc.save()
-        self.assertEqual(mydoc.to_json(),
-          '{"_id": "mydoc", "bla": {"bar": 42, "foo": "bar", "egg": 1262304000000}, "spam": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]}')
+        import json
+        self.assertEqual(json.loads(mydoc.to_json()),
+          json.loads('{"_id": "mydoc", "bla": {"bar": 42, "foo": "bar", "egg": 1262304000000}, "spam": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]}'))
         self.assertEqual(mydoc.to_json_type(),
           {'_id': 'mydoc', 'bla': {'egg': 1262304000000, 'foo': u'bar', 'bar': 42}, 'spam': [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]})
-
+ 
         mydoc = self.col.MyDoc()
         mydoc['_id'] = u'mydoc'
         mydoc.bla.foo = u"bar"
@@ -587,22 +590,22 @@ class JsonTestCase(unittest.TestCase):
         mydoc.bla.egg = datetime.datetime(2010, 1, 1)
         mydoc.spam = range(10)
         mydoc.save()
-        self.assertEqual(mydoc.to_json(),
-          '{"_id": "mydoc", "bla": {"bar": 42, "foo": "bar", "egg": 1262304000000}, "spam": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]}')
+        self.assertEqual(json.loads(mydoc.to_json()),
+          json.loads('{"_id": "mydoc", "bla": {"bar": 42, "foo": "bar", "egg": 1262304000000}, "spam": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]}'))
         self.assertEqual(mydoc.to_json_type(),
           {'_id': 'mydoc', 'bla': {'egg': 1262304000000, 'foo': u'bar', 'bar': 42}, 'spam': [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]})
-
+ 
         mydoc = self.col.MyDoc()
         mydoc['_id'] = u'mydoc2'
         mydoc.bla.foo = u"bar"
         mydoc.bla.bar = 42
         mydoc.spam = [datetime.datetime(2000, 1, 1), datetime.datetime(2008, 8, 8)]
         mydoc.save()
-        self.assertEqual(mydoc.to_json(),
-          '{"_id": "mydoc2", "bla": {"bar": 42, "foo": "bar", "egg": null}, "spam": [946684800000, 1218153600000]}')
+        self.assertEqual(json.loads(mydoc.to_json()),
+          json.loads('{"_id": "mydoc2", "bla": {"bar": 42, "foo": "bar", "egg": null}, "spam": [946684800000, 1218153600000]}'))
         self.assertEqual(mydoc.to_json_type(),
           {'_id': 'mydoc2', 'bla': {'egg': None, 'foo': u'bar', 'bar': 42}, 'spam': [946684800000, 1218153600000]})
-
+ 
     def test_to_json_with_i18n_and_dot_notation(self):
         class MyDoc(Document):
             use_dot_notation = True
@@ -616,7 +619,7 @@ class JsonTestCase(unittest.TestCase):
             }
             i18n = ['bla.foo']
         self.connection.register([MyDoc])
-
+ 
         mydoc = self.col.MyDoc()
         mydoc['_id'] = u'mydoc'
         mydoc.bla.foo = u"bar"
@@ -626,11 +629,12 @@ class JsonTestCase(unittest.TestCase):
         mydoc.set_lang('fr')
         mydoc.bla.foo = u"arf"
         mydoc.save()
+        import json
         self.assertEqual(mydoc.to_json_type(),
           {'_id': 'mydoc', 'bla': {'bar': 42, 'foo': {'fr': u'arf', 'en': u'bar'}, 'egg': 1262304000000}, 'spam': [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]})
-        self.assertEqual(mydoc.to_json(),
-          '{"_id": "mydoc", "bla": {"egg": 1262304000000, "foo": {"fr": "arf", "en": "bar"}, "bar": 42}, "spam": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]}')
-
+        self.assertEqual(json.loads(mydoc.to_json()),
+          json.loads('{"_id": "mydoc", "bla": {"egg": 1262304000000, "foo": {"fr": "arf", "en": "bar"}, "bar": 42}, "spam": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]}'))
+ 
         mydoc = self.col.MyDoc()
         mydoc['_id'] = u'mydoc2'
         mydoc.bla.foo = u"bar"
@@ -639,10 +643,10 @@ class JsonTestCase(unittest.TestCase):
         mydoc.save()
         self.assertEqual(mydoc.to_json_type(),
           {'_id': 'mydoc2', 'bla': {'bar': 42, 'foo': {'en': u'bar'}, 'egg': None}, 'spam': [946684800000, 1218153600000]})
-        self.assertEqual(mydoc.to_json(),
-          '{"_id": "mydoc2", "bla": {"egg": null, "foo": {"en": "bar"}, "bar": 42}, "spam": [946684800000, 1218153600000]}')
-
-
+        self.assertEqual(json.loads(mydoc.to_json()),
+          json.loads('{"_id": "mydoc2", "bla": {"egg": null, "foo": {"en": "bar"}, "bar": 42}, "spam": [946684800000, 1218153600000]}'))
+ 
+ 
     def test_from_json_with_list(self):
         class MyDoc(Document):
             structure = {
@@ -657,7 +661,7 @@ class JsonTestCase(unittest.TestCase):
         doc_from_json = self.col.MyDoc.from_json(json)
         doc_from_json.save()
         assert doc_from_json == mydoc
-
+ 
     def test_from_json_with_ref(self):
         class A(Document):
             structure = {
@@ -674,13 +678,13 @@ class JsonTestCase(unittest.TestCase):
         a['_id'] = u'a'
         a['foo'] = u'a'
         a.save()
-
+ 
         json = '{"_id": "b", "bar":1, "a":{"$id": "a", "$ref": "%s", "$db": "%s"}}' % (self.col.name, self.col.database.name)
         print json
         b = self.col.B.from_json(json)
         b.save()
         assert isinstance(b['a'], A), type(b['a'])
-
+ 
     def test_from_json_with_ref_in_list(self):
         class A(Document):
             structure = {
@@ -697,12 +701,12 @@ class JsonTestCase(unittest.TestCase):
         a['_id'] = u'a'
         a['foo'] = u'a'
         a.save()
-
+ 
         json = '{"_id": "b", "bar":1, "a":[{"$id": "a", "$ref": "%s", "$db": "%s"}]}' % (self.col.name, self.col.database.name)
         b = self.col.B.from_json(json)
         b.save()
         assert isinstance(b['a'][0], A), type(b['a'][0])
-
+ 
     def test_from_json_with_type_as_key(self):
         class MyDoc(Document):
             structure = {
@@ -712,12 +716,12 @@ class JsonTestCase(unittest.TestCase):
         mydoc = self.col.MyDoc()
         mydoc['_id'] = u'a'
         mydoc['foo'][u'bar'] = [u'bla', u'ble']
-
+ 
         json = '{"_id": "a", "foo": {"bar":["bla", "ble"]}}'
         mydoc_from_json = self.col.MyDoc.from_json(json)
         assert mydoc == mydoc_from_json, (mydoc, mydoc_from_json)
-
-
+ 
+ 
     def test_from_json_with_null_date(self):
         class MyDoc(Document):
             structure = {
@@ -725,7 +729,7 @@ class JsonTestCase(unittest.TestCase):
                 'date_in_list': [datetime.datetime],
             }
         self.connection.register([MyDoc])
-
+ 
         json = '{"_id": "a", "date": null, "date_in_list":[]}'
         mydoc_from_json = self.col.MyDoc.from_json(json)
         assert mydoc_from_json['_id'] == 'a'


### PR DESCRIPTION
as in pyhton and json the order of the keys is not garantee,
we cannot compare to_json output directly with a hardcoded string.
I'ts better to transform both the hardcoded dtring and the to_json
output in json with the json library and compare the 2 resulting objects
