### PR TITLE
fix OR operator and NOT operator

### DIFF
--- a/mongokit/operators.py
+++ b/mongokit/operators.py
@@ -58,9 +58,7 @@ class OR(SchemaOperator):
         return '<'+repr.join([i.__name__ for i in self._operands]) + '>'
 
     def validate(self, value):
-        if type(value) in self._operands:
-            return True
-        return False
+        return isinstance(value, tuple(self._operands))
 
 
 class NOT(SchemaOperator):
@@ -74,9 +72,7 @@ class NOT(SchemaOperator):
         return '<not '+repr.join([i.__name__ for i in self._operands]) + '>'
 
     def validate(self, value):
-        if type(value) in self._operands:
-            return False
-        return True
+        return not isinstance(value, tuple(self._operands))
 
 
 class IS(SchemaOperator):

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -366,13 +366,15 @@ class TypesTestCase(unittest.TestCase):
         class MyDoc(SchemaDocument):
             structure = {
                 "foo":OR(unicode,int),
-                "bar":OR(unicode, datetime)
+                "bar":OR(unicode, datetime),
+                "foobar": OR(basestring, int),
             }
 
         mydoc = MyDoc()
         assert str(mydoc.structure['foo']) == '<unicode or int>'
         assert str(mydoc.structure['bar']) == '<unicode or datetime>'
-        assert mydoc == {'foo': None, 'bar': None}
+        assert str(mydoc.structure['foobar']) == '<basestring or int>'
+        assert mydoc == {'foo': None, 'bar': None, 'foobar': None}
         mydoc['foo'] = 3.0
         self.assertRaises(SchemaTypeError, mydoc.validate)
         mydoc['foo'] = u"foo"
@@ -381,7 +383,6 @@ class TypesTestCase(unittest.TestCase):
         mydoc.validate()
         mydoc['foo'] = 'bar'
         self.assertRaises(SchemaTypeError, mydoc.validate)
-
         mydoc['foo'] = datetime.now()
         self.assertRaises(SchemaTypeError, mydoc.validate)
         mydoc['foo'] = u"foo"
@@ -391,6 +392,14 @@ class TypesTestCase(unittest.TestCase):
         mydoc.validate()
         mydoc['bar'] = 25
         self.assertRaises(SchemaTypeError, mydoc.validate)
+        mydoc['bar'] = u"bar"
+        mydoc["foo"] = u"foo"
+        mydoc["foobar"] = "foobar"
+        mydoc.validate()
+        mydoc["foobar"] = datetime.now()
+        self.assertRaises(SchemaTypeError, mydoc.validate)
+        mydoc["foobar"] = 3
+        mydoc.validate()
 
     def test_not_operator(self):
         from mongokit import NOT
@@ -407,15 +416,18 @@ class TypesTestCase(unittest.TestCase):
         class MyDoc(SchemaDocument):
             structure = {
                 "foo":NOT(unicode,int),
-                "bar":NOT(datetime)
+                "bar":NOT(datetime),
+                "foobar": NOT(basestring)
             }
 
         mydoc = MyDoc()
         assert str(mydoc.structure['foo']) == '<not unicode, not int>', str(mydoc.structure['foo'])
         assert str(mydoc.structure['bar']) == '<not datetime>'
-        assert mydoc == {'foo': None, 'bar': None}
+        assert str(mydoc.structure['foobar']) == '<not basestring>'
+        assert mydoc == {'foo': None, 'bar': None, 'foobar': None}
         assert mydoc['foo'] is None
         assert mydoc['bar'] is None
+        assert mydoc['foobar'] is None
         mydoc['foo'] = 3
         self.assertRaises(SchemaTypeError, mydoc.validate)
         mydoc['foo'] = u"foo"
@@ -430,6 +442,10 @@ class TypesTestCase(unittest.TestCase):
         mydoc['bar'] = u"today"
         mydoc.validate()
         mydoc['bar'] = 25
+        mydoc.validate()
+        mydoc['foobar'] = 'abc'
+        self.assertRaises(SchemaTypeError, mydoc.validate)
+        mydoc['foobar'] = 1
         mydoc.validate()
 
     def test_is_operator(self):


### PR DESCRIPTION
Hi, when I create a Document with a field of OR(basestring, int) and set it to some str or unicode, the document just does not validate, I think it's a bug.
