### PR TITLE
Import fixed

### DIFF
--- a/mongokit/mongo_exceptions.py
+++ b/mongokit/mongo_exceptions.py
@@ -27,10 +27,7 @@
 
 from bson import InvalidDocument
 
-try:
-    from pymongo.connection import OperationFailure
-except ImportError:
-    from pymongo.errors import OperationFailure
+from pymongo.errors import OperationFailure
 
 
 class ConnectionError(Exception):


### PR DESCRIPTION
With reference to issue #188, No name 'OperationFailure' in module 'pymongo.connection'.
 'OperationFailure'  is in 'pymongo.errors'.
