### PR TITLE
PEP 8 imports

### DIFF
--- a/mongokit/auth.py
+++ b/mongokit/auth.py
@@ -25,9 +25,10 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from mongokit import Document
 import hashlib
 import os
+
+from mongokit import Document
 
 
 class User(Document):


### PR DESCRIPTION
From PEP8:
 Imports should be grouped in the following order:

```
standard library imports
related third party imports
local application/library specific imports
```

You should put a blank line between each group of imports.
