### PR TITLE
Typos etc fixed

### DIFF
--- a/doc/pylons.txt
+++ b/doc/pylons.txt
@@ -2,10 +2,10 @@ Pylons support
 ==============
 
 You can very easily interface Mongokit with Pylons. This tutorial explains how to do this.
-Note that there's a lot of way to do the same thing. If you found another better solution,
+Note that there's a lot of ways to do the same thing. If you found another better solution,
 please contact me, I'll update this tutorial.
 
-Write you all models in ``model/``.  In the ``model/__init__.py``, import all the module
+Write all your models in ``model/``.  In the ``model/__init__.py``, import all the module
 you want to register and then add them to a list called `register_models`.
 
 Example of ``model/__init__.py``::
@@ -42,10 +42,10 @@ Then go to the ``lib/app_globals.py`` and edit this file so it look like this::
             self.connection.register(register_models)
 
 
-In this file, we create the connection (optionally the db if we use only on) and then
+In this file, we create the connection (and optionally the db if we use one) and then
 we register all our models.
 
-Now, you can access to the connection via the pylons.config :
+Now, you can access the connection via the pylons.config :
 
     config['pylons.app_globals'].connection
 
@@ -53,7 +53,6 @@ A more convenient way is to add the connection to the BaseController so you can 
 it just with ``self.connection``. The file ``lib/base.py`` has to look like this::
 
     from pylons.controllers import WSGIController
-    from pylons.templating import render_mako as render
     from pylons import config
     import pylons
 


### PR DESCRIPTION
from pylons.templating import render_mako as render - unnecessary since never used, may be misleading
